### PR TITLE
Fix Docker build warnings by standardizing FROM/AS keyword casing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build for smaller final image
 # Stage 1: Build dependencies
-FROM python:3.13.7-slim-bookworm as builder
+FROM python:3.13.7-slim-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -19,7 +19,7 @@ RUN pip install --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Playwright installation (separate for caching)
-FROM python:3.13.7-slim-bookworm as playwright-installer
+FROM python:3.13.7-slim-bookworm AS playwright-installer
 
 # Copy virtual environment from builder
 COPY --from=builder /opt/venv /opt/venv


### PR DESCRIPTION
Fixes Docker build warnings related to `FromAsCasing` by standardizing keyword casing in the Dockerfile.

## Changes
- Changed lowercase `as` to uppercase `AS` on line 3 (builder stage)
- Changed lowercase `as` to uppercase `AS` on line 22 (playwright-installer stage)

This ensures consistent casing between `FROM` and `AS` keywords in multi-stage build definitions, following Docker best practices and eliminating the two build warnings.