### PR TITLE
chore: exclude projects/ directory from GitHub scanning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Mark the projects directory as vendored code
+# This excludes it from Dependabot scanning and GitHub language statistics
+projects/** linguist-vendored
+


### PR DESCRIPTION
## Overview
This PR configures GitHub to exclude the `projects/` directory from Dependabot dependency scanning and ensures it's properly marked as vendored code.

## Changes
- Created `.gitattributes` file marking `projects/**` as `linguist-vendored`

## Impact
After merging this PR:
- ✅ Dependabot will no longer scan `projects/ActionsUptime/requirements.txt` and other dependencies in the projects directory
- ✅ The projects directory will be excluded from repository language statistics
- ✅ CodeQL scanning already excludes this directory (configured in `.github/codeql/codeql-config.yml`)

## Rationale
The `projects/` directory contains separate third-party projects (like ActionsUptime) that are maintained independently and should not be part of the main repository's dependency management workflow.