### PR TITLE
Enable auto-apply for prs rule

### DIFF
--- a/.cursor/rules/prs.mdc
+++ b/.cursor/rules/prs.mdc
@@ -1,5 +1,5 @@
 ---
 description: If you are an agent working in a git worktree
-alwaysApply: false
+alwaysApply: true
 ---
 After completing all the changes, create or update a PR with the changes.


### PR DESCRIPTION
This PR enables the `alwaysApply` flag for the `prs.mdc` cursor rule.

## Changes
- Set `alwaysApply: true` in `.cursor/rules/prs.mdc`

## Why
Previously, the `@prs` rule wasn't automatically triggering when the agent completed work in git worktrees. With `alwaysApply: false`, the rule had to be explicitly mentioned using `@prs` in prompts.

## Impact
Now the rule will automatically apply when working in git worktrees, and the agent will attempt to create or update PRs after completing changes without needing explicit mention.