### PR TITLE
feat: Customize Django admin to match website aesthetic

### DIFF
--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -1,0 +1,562 @@
+/* Custom Admin CSS to match website aesthetic */
+
+/* Base overrides - JetBrains Mono font and color scheme */
+#header,
+#content,
+#footer,
+body {
+    font-family: "JetBrains Mono", monospace !important;
+    font-weight: 500;
+}
+
+:root {
+    --primary: #000;
+    --secondary: #666;
+    --accent: #888;
+    --border-color: #000;
+    --border-thickness: 2px;
+    --line-height: 1.20rem;
+    --background-color: #fff;
+    --background-alt: #eee;
+    --text-color: #000;
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --primary: #fff;
+        --secondary: #aaa;
+        --accent: #888;
+        --border-color: #fff;
+        --background-color: #000;
+        --background-alt: #111;
+        --text-color: #fff;
+    }
+    
+    body {
+        background-color: var(--background-color) !important;
+        color: var(--text-color) !important;
+    }
+    
+    #header {
+        background: var(--background-color) !important;
+        color: var(--text-color) !important;
+        border-bottom: var(--border-thickness) solid var(--border-color) !important;
+    }
+    
+    .module {
+        background: var(--background-color) !important;
+        border: var(--border-thickness) solid var(--border-color) !important;
+    }
+    
+    .module h2, .module caption {
+        background: var(--background-alt) !important;
+        color: var(--text-color) !important;
+    }
+    
+    table thead th {
+        background: var(--background-alt) !important;
+        color: var(--text-color) !important;
+    }
+    
+    input, select, textarea {
+        background: var(--background-color) !important;
+        color: var(--text-color) !important;
+        border-color: var(--border-color) !important;
+    }
+    
+    .button, input[type="submit"], input[type="button"], .submit-row input {
+        background: var(--background-alt) !important;
+        color: var(--text-color) !important;
+        border-color: var(--border-color) !important;
+    }
+    
+    .button:hover, input[type="submit"]:hover, input[type="button"]:hover {
+        background: var(--background-color) !important;
+    }
+    
+    #changelist-filter {
+        background: var(--background-color) !important;
+        border-left: var(--border-thickness) solid var(--border-color) !important;
+    }
+    
+    #changelist-filter h2 {
+        background: var(--background-alt) !important;
+    }
+    
+    #changelist-filter li.selected a {
+        color: var(--text-color) !important;
+        font-weight: 600;
+    }
+    
+    .paginator a, .paginator span {
+        background: var(--background-alt) !important;
+        color: var(--text-color) !important;
+        border-color: var(--border-color) !important;
+    }
+}
+
+/* Header styling */
+#header {
+    background: var(--background-color);
+    color: var(--text-color);
+    border-bottom: var(--border-thickness) solid var(--border-color);
+    padding: calc(var(--line-height) * 1.5) 2ch;
+    font-weight: 500;
+}
+
+#branding h1 {
+    font-family: "JetBrains Mono", monospace;
+    font-weight: 800;
+    text-transform: uppercase;
+    margin: 0;
+    padding: 0;
+    font-size: 2rem;
+    line-height: calc(2 * var(--line-height));
+}
+
+#branding h1 a {
+    color: var(--text-color);
+    text-decoration: none;
+}
+
+/* Remove Django branding link */
+#site-name a:hover {
+    color: var(--text-color);
+}
+
+/* User tools */
+#user-tools {
+    font-weight: 500;
+    text-align: right;
+    margin: 0;
+    padding: 0;
+    text-transform: none;
+}
+
+#user-tools a {
+    color: var(--text-color);
+    text-decoration: underline;
+    text-decoration-thickness: var(--border-thickness);
+}
+
+/* Content area */
+#content {
+    background: var(--background-color);
+    padding: var(--line-height) 2ch;
+}
+
+/* Login form */
+.login {
+    background: var(--background-color);
+}
+
+.login #content {
+    padding: calc(var(--line-height) * 2) 2ch;
+}
+
+.login #header {
+    height: auto;
+    padding: calc(var(--line-height) * 2) 2ch;
+}
+
+.login #header h1 {
+    font-size: 2rem;
+    text-transform: uppercase;
+}
+
+.login #header h1 a {
+    color: var(--text-color);
+}
+
+.login #content-main {
+    width: 100%;
+    max-width: 60ch;
+    margin: 0 auto;
+}
+
+.login form {
+    border: var(--border-thickness) solid var(--border-color);
+    padding: calc(var(--line-height) * 2) 2ch;
+    margin-top: calc(var(--line-height) * 2);
+}
+
+.login .form-row {
+    padding: var(--line-height) 0;
+    border-bottom: none;
+}
+
+.login .form-row label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: calc(var(--line-height) / 2);
+    text-transform: uppercase;
+}
+
+/* Input fields */
+input[type="text"],
+input[type="password"],
+input[type="email"],
+input[type="url"],
+input[type="number"],
+textarea,
+select {
+    font-family: "JetBrains Mono", monospace !important;
+    border: var(--border-thickness) solid var(--border-color);
+    padding: calc(var(--line-height) / 2) 1ch;
+    background: var(--background-color);
+    color: var(--text-color);
+    font-size: 16px;
+    font-weight: 500;
+    width: 100%;
+}
+
+input[type="text"]:focus,
+input[type="password"]:focus,
+input[type="email"]:focus,
+input[type="url"]:focus,
+input[type="number"]:focus,
+textarea:focus,
+select:focus {
+    border-width: 3px;
+    outline: none;
+}
+
+/* Buttons */
+.button,
+input[type="submit"],
+input[type="button"],
+.submit-row input,
+button {
+    font-family: "JetBrains Mono", monospace !important;
+    background: var(--background-alt);
+    color: var(--text-color);
+    border: var(--border-thickness) solid var(--border-color);
+    padding: calc(var(--line-height) / 2) 2ch;
+    font-size: 16px;
+    font-weight: 600;
+    text-transform: uppercase;
+    cursor: pointer;
+    text-decoration: none;
+    display: inline-block;
+}
+
+.button:hover,
+input[type="submit"]:hover,
+input[type="button"]:hover,
+.submit-row input:hover,
+button:hover {
+    background: var(--background-color);
+    transform: none;
+}
+
+.button:active,
+input[type="submit"]:active,
+input[type="button"]:active,
+button:active {
+    transform: translate(2px, 2px);
+}
+
+/* Tables */
+table {
+    border-collapse: collapse;
+    border: var(--border-thickness) solid var(--border-color);
+    font-family: "JetBrains Mono", monospace;
+}
+
+table th,
+table td {
+    border: var(--border-thickness) solid var(--border-color);
+    padding: calc(var(--line-height) / 2) 1ch;
+    text-align: left;
+}
+
+table thead th {
+    background: var(--background-alt);
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+/* Module styling */
+.module {
+    border: var(--border-thickness) solid var(--border-color);
+    margin-bottom: calc(var(--line-height) * 2);
+}
+
+.module h2,
+.module caption {
+    background: var(--background-alt);
+    color: var(--text-color);
+    font-weight: 600;
+    text-transform: uppercase;
+    padding: calc(var(--line-height) / 2) 1ch;
+    margin: 0;
+    border-bottom: var(--border-thickness) solid var(--border-color);
+}
+
+.module h3 {
+    font-weight: 600;
+    text-transform: uppercase;
+    margin: var(--line-height) 0;
+}
+
+/* Dashboard modules */
+#content-main .module {
+    border: var(--border-thickness) solid var(--border-color);
+}
+
+.module ul {
+    padding-left: 0;
+    margin: 0;
+}
+
+.module ul li {
+    list-style: none;
+    padding: calc(var(--line-height) / 2) 1ch;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.module ul li:last-child {
+    border-bottom: none;
+}
+
+.module a {
+    color: var(--text-color);
+    text-decoration: underline;
+    text-decoration-thickness: var(--border-thickness);
+}
+
+/* Breadcrumbs */
+.breadcrumbs {
+    background: var(--background-alt);
+    padding: calc(var(--line-height) / 2) 2ch;
+    border-bottom: var(--border-thickness) solid var(--border-color);
+    font-weight: 500;
+}
+
+.breadcrumbs a {
+    color: var(--text-color);
+    text-decoration: underline;
+    text-decoration-thickness: var(--border-thickness);
+}
+
+/* Pagination */
+.paginator {
+    font-weight: 500;
+}
+
+.paginator a,
+.paginator span {
+    border: var(--border-thickness) solid var(--border-color);
+    padding: calc(var(--line-height) / 4) 1ch;
+    margin: 0 calc(1ch / 2);
+    text-decoration: none;
+    background: var(--background-alt);
+    color: var(--text-color);
+}
+
+.paginator a:hover {
+    background: var(--background-color);
+}
+
+.paginator .this-page {
+    font-weight: 600;
+}
+
+/* Messages */
+.messagelist {
+    margin: 0 0 var(--line-height);
+    padding: 0;
+}
+
+.messagelist li {
+    border: var(--border-thickness) solid var(--border-color);
+    padding: var(--line-height) 2ch;
+    margin-bottom: var(--line-height);
+    list-style: none;
+    font-weight: 500;
+}
+
+.messagelist .success {
+    background: rgba(40, 167, 69, 0.15);
+    border-color: #28a745;
+}
+
+.messagelist .warning {
+    background: rgba(255, 193, 7, 0.15);
+    border-color: #ffc107;
+}
+
+.messagelist .error {
+    background: rgba(220, 53, 69, 0.15);
+    border-color: #dc3545;
+}
+
+/* Remove Django admin icons and graphics */
+.addlink::before,
+.changelink::before,
+.deletelink::before {
+    display: none;
+}
+
+.addlink,
+.changelink,
+.deletelink {
+    padding-left: 0;
+}
+
+/* Sidebar filters */
+#changelist-filter {
+    background: var(--background-color);
+    border-left: var(--border-thickness) solid var(--border-color);
+}
+
+#changelist-filter h2 {
+    background: var(--background-alt);
+    font-weight: 600;
+    text-transform: uppercase;
+    padding: calc(var(--line-height) / 2) 1ch;
+    border-bottom: var(--border-thickness) solid var(--border-color);
+}
+
+#changelist-filter h3 {
+    font-weight: 600;
+    margin: var(--line-height) 1ch calc(var(--line-height) / 2);
+    text-transform: uppercase;
+}
+
+#changelist-filter ul {
+    padding: 0 1ch;
+    margin: 0 0 var(--line-height);
+}
+
+#changelist-filter li {
+    list-style: none;
+    margin: calc(var(--line-height) / 2) 0;
+}
+
+#changelist-filter a {
+    color: var(--text-color);
+    text-decoration: underline;
+    text-decoration-thickness: var(--border-thickness);
+}
+
+#changelist-filter li.selected a {
+    font-weight: 600;
+}
+
+/* Form rows */
+.form-row {
+    padding: var(--line-height) 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.form-row:last-child {
+    border-bottom: none;
+}
+
+/* Help text */
+.help {
+    color: var(--secondary);
+    font-weight: 500;
+    margin-top: calc(var(--line-height) / 2);
+}
+
+/* Errors */
+.errorlist {
+    margin: calc(var(--line-height) / 2) 0;
+    padding: calc(var(--line-height) / 2) 1ch;
+    background: rgba(220, 53, 69, 0.15);
+    border: var(--border-thickness) solid #dc3545;
+    color: var(--text-color);
+    list-style: none;
+}
+
+/* Submit row */
+.submit-row {
+    padding: var(--line-height) 0;
+    margin: var(--line-height) 0 0;
+    border-top: var(--border-thickness) solid var(--border-color);
+    text-align: right;
+}
+
+/* Calendar widget */
+.calendarbox,
+.clockbox {
+    border: var(--border-thickness) solid var(--border-color) !important;
+    background: var(--background-color) !important;
+}
+
+.calendar caption,
+.calendarbox h2 {
+    background: var(--background-alt) !important;
+    color: var(--text-color) !important;
+}
+
+/* Inline forms */
+.inline-group {
+    border: var(--border-thickness) solid var(--border-color);
+    padding: var(--line-height) 1ch;
+    margin-bottom: calc(var(--line-height) * 2);
+}
+
+.inline-group .tabular {
+    border: none;
+}
+
+/* Results list */
+#changelist .results {
+    overflow-x: auto;
+}
+
+/* Remove default icon backgrounds */
+.deletelink,
+.addlink,
+.changelink,
+.viewlink {
+    background-image: none !important;
+}
+
+/* Action checkboxes */
+.action-checkbox {
+    vertical-align: middle;
+}
+
+/* Object tools */
+.object-tools {
+    margin: 0 0 var(--line-height);
+}
+
+.object-tools a {
+    background: var(--background-alt);
+    color: var(--text-color);
+    border: var(--border-thickness) solid var(--border-color);
+    padding: calc(var(--line-height) / 2) 2ch;
+    font-weight: 600;
+    text-transform: uppercase;
+    text-decoration: none;
+}
+
+.object-tools a:hover {
+    background: var(--background-color);
+}
+
+/* Dashboard cards */
+#content-main .dashboard {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(40ch, 1fr));
+    gap: calc(var(--line-height) * 2);
+}
+
+/* Responsive */
+@media screen and (max-width: 480px) {
+    body {
+        font-size: 14px;
+    }
+    
+    #header,
+    #content {
+        padding: var(--line-height) 1ch;
+    }
+}
+

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,0 +1,19 @@
+{% extends "admin/base.html" %}
+{% load static %}
+
+{% block title %}{% if subtitle %}{{ subtitle }} | {% endif %}{{ title }} | Admin{% endblock %}
+
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">AARON SPINDLER</a></h1>
+{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+<link rel="stylesheet" type="text/css" href="{% static 'css/admin.css' %}">
+<link rel="preload" href="{% static 'fonts/jetbrains-mono-regular.woff2' %}" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="{% static 'fonts/jetbrains-mono-medium.woff2' %}" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="{% static 'fonts/jetbrains-mono-bold.woff2' %}" as="font" type="font/woff2" crossorigin="anonymous">
+{% endblock %}
+
+{% block nav-global %}{% endblock %}
+

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,0 +1,96 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block bodyclass %}{{ block.super }} dashboard{% endblock %}
+
+{% block breadcrumbs %}{% endblock %}
+
+{% block content %}
+<div id="content-main">
+    <h2 style="text-transform: uppercase; font-weight: 800; margin-bottom: calc(var(--line-height) * 2);">Admin Dashboard</h2>
+
+    {% if user.is_active and user.is_staff %}
+    <div class="dashboard">
+        {% for app in app_list %}
+        <div class="module">
+            <h2>
+                <a href="{{ app.app_url }}" class="section">{{ app.name }}</a>
+            </h2>
+            <table>
+                <tbody>
+                {% for model in app.models %}
+                <tr class="model-{{ model.object_name|lower }}">
+                    {% if model.admin_url %}
+                    <th scope="row">
+                        <a href="{{ model.admin_url }}">{{ model.name }}</a>
+                    </th>
+                    {% else %}
+                    <th scope="row">{{ model.name }}</th>
+                    {% endif %}
+
+                    <td>
+                        {% if model.add_url %}
+                        <a href="{{ model.add_url }}" class="addlink">{% translate 'Add' %}</a>
+                        {% else %}
+                        &nbsp;
+                        {% endif %}
+                    </td>
+
+                    <td>
+                        {% if model.admin_url %}
+                        {% if model.view_only %}
+                        <a href="{{ model.admin_url }}" class="viewlink">{% translate 'View' %}</a>
+                        {% else %}
+                        <a href="{{ model.admin_url }}" class="changelink">{% translate 'Change' %}</a>
+                        {% endif %}
+                        {% else %}
+                        &nbsp;
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endfor %}
+    </div>
+    {% else %}
+    <p style="margin-top: calc(var(--line-height) * 2);">
+        {% translate "You don't have permission to view or edit anything." %}
+    </p>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<div id="content-related">
+    <div class="module" id="recent-actions-module">
+        <h2>{% translate 'Recent actions' %}</h2>
+        <h3>{% translate 'My actions' %}</h3>
+        {% load log %}
+        {% get_admin_log 10 as admin_log for_user user %}
+        {% if not admin_log %}
+        <p style="padding: calc(var(--line-height) / 2) 1ch;">{% translate 'None available' %}</p>
+        {% else %}
+        <ul>
+        {% for entry in admin_log %}
+        <li class="{% if entry.is_addition %}addlink{% endif %}{% if entry.is_change %}changelink{% endif %}{% if entry.is_deletion %}deletelink{% endif %}">
+            {% if entry.is_deletion or not entry.get_admin_url %}
+                {{ entry.object_repr }}
+            {% else %}
+                <a href="{{ entry.get_admin_url }}">{{ entry.object_repr }}</a>
+            {% endif %}
+            <br>
+            {% if entry.content_type %}
+                <span style="color: var(--secondary);">{{ entry.content_type.name|capfirst }}</span>
+            {% else %}
+                <span style="color: var(--secondary);">{% translate 'Unknown content' %}</span>
+            {% endif %}
+        </li>
+        {% endfor %}
+        </ul>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}
+

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -1,0 +1,61 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block bodyclass %}{{ block.super }} login{% endblock %}
+
+{% block nav-global %}{% endblock %}
+
+{% block content_title %}{% endblock %}
+
+{% block breadcrumbs %}{% endblock %}
+
+{% block content %}
+<div id="content-main">
+    {% if form.errors and not form.non_field_errors %}
+    <p class="errornote">
+        {% if form.errors.items|length == 1 %}
+            {% translate "Please correct the error below." %}
+        {% else %}
+            {% translate "Please correct the errors below." %}
+        {% endif %}
+    </p>
+    {% endif %}
+
+    {% if form.non_field_errors %}
+    {% for error in form.non_field_errors %}
+    <p class="errornote">
+        {{ error }}
+    </p>
+    {% endfor %}
+    {% endif %}
+
+    <form action="{{ app_path }}" method="post" id="login-form">
+        {% csrf_token %}
+        
+        <div class="form-row">
+            {{ form.username.errors }}
+            {{ form.username.label_tag }}
+            {{ form.username }}
+        </div>
+        
+        <div class="form-row">
+            {{ form.password.errors }}
+            {{ form.password.label_tag }}
+            {{ form.password }}
+            <input type="hidden" name="next" value="{{ next }}">
+        </div>
+
+        {% url 'admin_password_reset' as password_reset_url %}
+        {% if password_reset_url %}
+        <div class="password-reset-link" style="margin-top: calc(var(--line-height) * 1.5);">
+            <a href="{{ password_reset_url }}">{% translate 'Forgotten your password or username?' %}</a>
+        </div>
+        {% endif %}
+
+        <div class="submit-row" style="margin-top: calc(var(--line-height) * 2); text-align: left;">
+            <input type="submit" value="{% translate 'Log in' %}">
+        </div>
+    </form>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
This PR customizes the Django admin interface to match the website's minimalist, monospace aesthetic and removes all Django branding.

## Changes
- **Custom CSS** (`static/css/admin.css`): 
  - JetBrains Mono font throughout admin
  - Black/white color scheme with dark mode support
  - 2px borders consistent with main site
  - Clean, minimal styling for all admin components

- **Custom Base Template** (`templates/admin/base_site.html`):
  - Changed branding from "Django administration" to "AARON SPINDLER"
  - Removed Django navigation links
  - Loads custom fonts and CSS

- **Custom Login Page** (`templates/admin/login.html`):
  - Removed all Django boilerplate text
  - Clean, minimal form design
  - Uppercase labels matching site style

- **Custom Admin Homepage** (`templates/admin/index.html`):
  - Custom "Admin Dashboard" header
  - Clean module layout with consistent table styling
  - Recent actions sidebar
  - Text-only links (no icons)

## Design Features
✅ JetBrains Mono monospace font
✅ High-contrast black/white design
✅ Dark mode support via CSS media queries
✅ 2px solid borders matching main site
✅ Uppercase headings and labels
✅ Zero Django branding or logos
✅ Responsive design
✅ Consistent with website's minimalist aesthetic

## Testing
- [ ] Verify admin login page displays correctly
- [ ] Verify admin homepage loads with new styling
- [ ] Verify dark mode works properly
- [ ] Test on mobile devices
- [ ] Verify all admin forms and tables render correctly